### PR TITLE
Add metric for carriers' locations over time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@imnotteixeira/covid-19-simulator",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,15 +30,6 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "@babel/runtime": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-      "dev": true,
-      "requires": {
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -107,9 +98,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.13.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.2.tgz",
-      "integrity": "sha512-LB2R1Oyhpg8gu4SON/mfforE525+Hi/M1ineICEDftqNVTyFg1aRIeGuTvXAoWHc4nbrFncWtJgMmoyRvuGh7A==",
+      "version": "14.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.10.tgz",
+      "integrity": "sha512-Bz23oN/5bi0rniKT24ExLf4cK0JdvN3dH/3k0whYkdN4eI4vS2ZW/2ENNn2uxHCzWcbdHIa/GRuWQytfzCjRYw==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -858,9 +849,9 @@
       "dev": true
     },
     "execa": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.0.tgz",
-      "integrity": "sha512-JbDUxwV3BoT5ZVXQrSVbAiaXhXUkIwvbhPIwZ0N13kX+5yCzOhUNdocxB/UQRuYOHRYYwAxKYwJYc0T4D12pDA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.2.tgz",
+      "integrity": "sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==",
       "dev": true,
       "requires": {
         "cross-spawn": "^7.0.0",
@@ -875,9 +866,9 @@
       },
       "dependencies": {
         "cross-spawn": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
-          "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "dev": true,
           "requires": {
             "path-key": "^3.1.0",
@@ -1111,9 +1102,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
     },
     "hard-rejection": {
@@ -1595,10 +1586,13 @@
       }
     },
     "is-wsl": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
-      "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==",
-      "dev": true
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
     },
     "is-yarn-global": {
       "version": "0.3.0",
@@ -1666,6 +1660,12 @@
       "requires": {
         "json-buffer": "3.0.0"
       }
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true
     },
     "latest-version": {
       "version": "5.1.0",
@@ -2003,22 +2003,30 @@
       }
     },
     "meow": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-6.1.0.tgz",
-      "integrity": "sha512-iIAoeI01v6pmSfObAAWFoITAA4GgiT45m4SmJgoxtZfvI0fyZwhV4d0lTwiUXvAKIPlma05Feb2Xngl52Mj5Cg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-6.1.1.tgz",
+      "integrity": "sha512-3YffViIt2QWgTy6Pale5QpopX/IvU3LPL03jOTqp6pGj3VjesdO/U8CuHMKpnQr4shCNCM5fd5XFFvIIl6JBHg==",
       "dev": true,
       "requires": {
         "@types/minimist": "^1.2.0",
-        "camelcase-keys": "^6.1.1",
+        "camelcase-keys": "^6.2.2",
         "decamelize-keys": "^1.1.0",
-        "hard-rejection": "^2.0.0",
-        "minimist-options": "^4.0.1",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "^4.0.2",
         "normalize-package-data": "^2.5.0",
-        "read-pkg-up": "^7.0.0",
+        "read-pkg-up": "^7.0.1",
         "redent": "^3.0.0",
         "trim-newlines": "^3.0.0",
-        "type-fest": "^0.8.1",
-        "yargs-parser": "^18.1.1"
+        "type-fest": "^0.13.1",
+        "yargs-parser": "^18.1.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+          "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+          "dev": true
+        }
       }
     },
     "merge-stream": {
@@ -2040,9 +2048,9 @@
       "dev": true
     },
     "min-indent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
-      "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
     },
     "minimatch": {
@@ -2061,13 +2069,14 @@
       "dev": true
     },
     "minimist-options": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.0.2.tgz",
-      "integrity": "sha512-seq4hpWkYSUh1y7NXxzucwAN9yVlBc3Upgdjz8vLCP97jG8kaOmzYrVH/m7tQ1NYD1wdtZbSLfdy4zFmRWuc/w==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
       "dev": true,
       "requires": {
         "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0"
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
       }
     },
     "mkdirp": {
@@ -2153,9 +2162,9 @@
       "dev": true
     },
     "np": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/np/-/np-6.2.2.tgz",
-      "integrity": "sha512-C+5nIA9wnXlSK63TcoI5ajszCvjLVdXM9zC/4i80ewdxvGGeSiDlzo8bNbZ2LYBLNoezT487bE5J3qIzthIhGQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/np/-/np-6.2.3.tgz",
+      "integrity": "sha512-EuRlncnTPL6e/p1lqa1lbrTPPddT3KWpTvztTmOCrB2/ZvHp73xqljoUh7xSm+NTipbrcSacTDSlDZt8N6MeWg==",
       "dev": true,
       "requires": {
         "@samverschueren/stream-to-observable": "^0.3.0",
@@ -2322,9 +2331,9 @@
       }
     },
     "open": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.0.3.tgz",
-      "integrity": "sha512-sP2ru2v0P290WFfv49Ap8MF6PkzGNnGlAwHweB4WR4mr5d2d0woiCluUeJ218w7/+PmoBy9JmYgD5A4mLcWOFA==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.0.4.tgz",
+      "integrity": "sha512-brSA+/yq+b08Hsr4c8fsEW2CRzk1BmfN3SAK/5VCHQ9bdoZJ4qa/+AfR0xHjlbbZUyPkUHs1b8x1RqdyZdkVqQ==",
       "dev": true,
       "requires": {
         "is-docker": "^2.0.0",
@@ -2658,12 +2667,6 @@
         }
       }
     },
-    "regenerator-runtime": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-      "dev": true
-    },
     "regexpp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
@@ -2817,9 +2820,9 @@
       }
     },
     "spdx-correct": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -2833,9 +2836,9 @@
       "dev": true
     },
     "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -3329,13 +3332,10 @@
       "dev": true
     },
     "yaml": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.9.2.tgz",
-      "integrity": "sha512-HPT7cGGI0DuRcsO51qC1j9O16Dh1mZ2bnXwsi0jrSpsLz0WxOLSLXfkABVl6bZO629py3CU+OMJtpNHDLB97kg==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.9.2"
-      }
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
+      "dev": true
     },
     "yargs-parser": {
       "version": "18.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imnotteixeira/covid-19-simulator",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A Simulator for the COVID-19 epidemic, to analyse measures effectiveness.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imnotteixeira/covid-19-simulator",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "A Simulator for the COVID-19 epidemic, to analyse measures effectiveness.",
   "main": "src/index.js",
   "scripts": {
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/imnotteixeira/covid-19-simulator.js#readme",
   "devDependencies": {
     "eslint": "^6.8.0",
-    "np": "^6.2.2"
+    "np": "^6.2.3"
   },
   "dependencies": {}
 }

--- a/src/disease/transmission.js
+++ b/src/disease/transmission.js
@@ -19,27 +19,17 @@ const contaminate = (population, carriers, i) => {
 // This can be memoized
 const getAffectedCoords = (line, col, spreadRadius, matrixSide) => {
     const affected = [];
-    for (let i = 1; i <= spreadRadius; i++) {
-        for (let j = 1; j <= spreadRadius; j++) {
-            // vertical
-            affected.push([line + i, col]);
-            affected.push([line - i, col]);
-            // horizontal
-            affected.push([line, col - j]);
-            affected.push([line, col + j]);
-            // diagonals
-            affected.push([line - i, col - j]);
-            affected.push([line - i, col + j]);
-            affected.push([line + i, col - j]);
-            affected.push([line + i, col + j]);
+    for (let x = col - spreadRadius; x <= col + spreadRadius; x++) {
+        for (let y = line - spreadRadius; y <= line + spreadRadius; y++) {
+            if (x >= 0
+                && x < matrixSide
+                && y >= 0
+                && y < matrixSide
+                && !(x === line && y === col))
+                affected.push([y, x]);
         }
     }
-    return affected.filter(([x, y]) =>
-        x >= 0
-        && x < matrixSide
-        && y >= 0
-        && y < matrixSide,
-    );
+    return affected;
 };
 
 const isViableTarget = (population, i) =>

--- a/src/init.js
+++ b/src/init.js
@@ -140,8 +140,9 @@ module.exports = (inputData) => {
     // eslint-disable-next-line no-param-reassign
     if (!populationSize) populationSize = PopulationPresets[populationPreset].size;
 
+    const matrixSide = Math.sqrt(populationSize);
     // eslint-disable-next-line no-param-reassign
-    initialCarriers = [(populationSize / 2) + (Math.sqrt(populationSize) / 2)];
+    initialCarriers = [((Math.floor(matrixSide / 2)) * matrixSide) + (matrixSide / 2)];
 
     const population = initPopulation(populationSize, config); // TODO pass S distribution to attribute S to each individual on setup
 

--- a/src/metrics/collectors.js
+++ b/src/metrics/collectors.js
@@ -8,6 +8,7 @@ const {
     countConfirmedCarriers,
     countTotalTests,
     countPositiveTests,
+    updateCarriersHistory,
 } = require("./count");
 const { updateValue } = require("./update");
 
@@ -25,4 +26,5 @@ module.exports = () => {
     MetricsService.register("positive-test-count", countPositiveTests, []);
     MetricsService.register("total-test-count", countTotalTests, []);
     MetricsService.register("confirmed-carrier-count", countConfirmedCarriers, []);
+    MetricsService.register("carriers-history", updateCarriersHistory, []);
 };

--- a/src/metrics/count.js
+++ b/src/metrics/count.js
@@ -1,3 +1,5 @@
+const { isContaminated } = require("../utils/index");
+
 const countCarriers = (setData) => ({ carriers }) => {
     setData((data) => ([...data, carriers.length]));
 };
@@ -34,6 +36,10 @@ const countPositiveTests = (setData) => ({ newPositiveTests }) => {
     setData((data) => ([...data, newPositiveTests]));
 };
 
+const updateCarriersHistory = (setData) => ({ population }) => {
+    setData((data) => ([...data, population.map((_, i) => isContaminated(population, i) ? 1 : 0)]));
+};
+
 module.exports = {
     countCarriers,
     countDead,
@@ -44,4 +50,5 @@ module.exports = {
     countConfirmedCarriers,
     countTotalTests,
     countPositiveTests,
+    updateCarriersHistory,
 };

--- a/src/metrics/index.js
+++ b/src/metrics/index.js
@@ -38,10 +38,10 @@ class MetricsService {
     }
 
     export() {
-        const metrics = [];
+        const metrics = {};
         this.metricsData.forEach((data, id) => {
             if (this.subscribedCollectors.has(id))
-                metrics.push({ id, data });
+                metrics[id] = data;
         });
         return metrics;
     }


### PR DESCRIPTION
Registered a new metric called `carriers-history` that returns an array of population snapshots, where each individual is a 0 or 1, meaning he's not infected or vice-versa, respectively.

Fixed disease transmission issues, improving the spread area calculation algorithm.

Added onSimulationStart hook and moved the hook calls to `simualteStep`, so that all dependents of the engine can use the hooks correctly

Metrics are now exported as an object 
```
{
"metric_id": <metricData>,
....
}
```